### PR TITLE
Fix and update api_spec.yaml

### DIFF
--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -16,9 +16,12 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/OrderInput'
+                type: object
+                properties:
+                  orders:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OrderOutput'
     post:
       summary: Place a new order
       operationId: placeOrder
@@ -35,13 +38,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderInput'
+                $ref: '#/components/schemas/OrderOutput'
         '400':
           description: Invalid input
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
   /orders/{orderId}:
     parameters:
       - name: orderId
@@ -58,7 +62,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderInput'
+                $ref: '#/components/schemas/OrderOutput'
         '404':
           description: Order not found
           content:
@@ -86,25 +90,28 @@ paths:
           description: WebSocket connection established
         '426':
           description: Upgrade Required
+
+
 components:
   schemas:
     OrderInput:
       type: object
       properties:
-        stoks:
+        stock_symbol:
           type: string
-          description: Currency pair symbol (e.g. 'EURUSD'), or any other stuff 
+          description: Currency pair symbol (e.g. 'EURUSD'), or any other stuff
         quantity:
           type: number
           format: double
           description: Quantity of the currency pair to be traded
+
     OrderOutput:
       type: object
       properties:
         id:
           type: string
           description: Unique identifier for the order
-        stoks:
+        stock_symbol:
           type: string
           description: Currency pair symbol (e.g. 'EURUSD')
         quantity:
@@ -113,9 +120,9 @@ components:
           description: Quantity of the currency pair to be traded
         status:
           type: string
-          enum: [pending, executed, canceled]
+          enum: [PENDING, EXECUTED, CANCELED]
           description: Status of the order
-          
+
     Error:
       type: object
       properties:


### PR DESCRIPTION
- Rename the 'stoks' field to 'stock_symbol' for improved clarity and consistency.
- Fix the references to response schemas to ensure accurate documentation.
- Update the response schema for fetching a list of orders to align with the latest implementation.